### PR TITLE
Fix and-or ignore ci linting warnings

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,6 +1,7 @@
 {:linters {:if {:level :off}
            :unused-namespace {:level :off}
            :unused-binding {:level :off}
+           :shadowed-var {:level :off}
            :unresolved-symbol
            {:exclude
             [(clojure.core.match/match)

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -28,6 +28,6 @@ jobs:
       - name: Get leiningen version
         run: lein -v
       - name: Run linter
-        run: lein lint
+        run: lein lint || test $? -eq 2
       - name: Run tests
         run: lein test


### PR DESCRIPTION
## Description:
* Adds an exclusion for shadowed vars in clj kondo config
* Also creates a universal ignore for warnings in the CI pipeline

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.
  - [x] My changes generate no new warnings (check the console)