### PR TITLE
Fix Docker CI: replace nc healthcheck with bash /dev/tcp, fix shellch…

### DIFF
--- a/docker-compose-build.yaml
+++ b/docker-compose-build.yaml
@@ -37,11 +37,11 @@ services:
       - ./data:/data
       - ./logs:/logs
     healthcheck:
-      test: ["CMD-SHELL", "nc -z localhost 4334"]
+      test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/4334'"]
       interval: 5s
       timeout: 3s
-      retries: 10
-      start_period: 10s
+      retries: 20
+      start_period: 30s
     restart: always
   web:
     image: nginx:alpine

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,11 +33,11 @@ services:
       - ./data:/data
       - ./logs:/logs
     healthcheck:
-      test: ["CMD-SHELL", "nc -z localhost 4334"]
+      test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/4334'"]
       interval: 5s
       timeout: 3s
-      retries: 10
-      start_period: 10s
+      retries: 20
+      start_period: 30s
     restart: always
   web:
     image: nginx:alpine

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -29,10 +29,10 @@ color_red='\033[0;31m'
 color_cyan='\033[0;36m'
 color_reset='\033[0m'
 
-info()  { printf "${color_green}[INFO]${color_reset}  %s\n" "$*"; }
-warn()  { printf "${color_yellow}[WARN]${color_reset}  %s\n" "$*"; }
-error() { printf "${color_red}[ERROR]${color_reset} %s\n" "$*" >&2; }
-header() { printf "\n${color_cyan}=== %s ===${color_reset}\n\n" "$*"; }
+info()  { printf '%s[INFO]%s  %s\n' "$color_green" "$color_reset" "$*"; }
+warn()  { printf '%s[WARN]%s  %s\n' "$color_yellow" "$color_reset" "$*"; }
+error() { printf '%s[ERROR]%s %s\n' "$color_red" "$color_reset" "$*" >&2; }
+header() { printf '\n%s=== %s ===%s\n\n' "$color_cyan" "$*" "$color_reset"; }
 
 generate_password() {
   # Generate a URL-safe random password (no special chars that break URLs/YAML)

--- a/docker-user.sh
+++ b/docker-user.sh
@@ -29,9 +29,9 @@ color_red='\033[0;31m'
 color_yellow='\033[1;33m'
 color_reset='\033[0m'
 
-info()  { printf "${color_green}[OK]${color_reset}    %s\n" "$*"; }
-error() { printf "${color_red}[ERROR]${color_reset} %s\n" "$*" >&2; }
-warn()  { printf "${color_yellow}[WARN]${color_reset}  %s\n" "$*"; }
+info()  { printf '%s[OK]%s    %s\n' "$color_green" "$color_reset" "$*"; }
+error() { printf '%s[ERROR]%s %s\n' "$color_red" "$color_reset" "$*" >&2; }
+warn()  { printf '%s[WARN]%s  %s\n' "$color_yellow" "$color_reset" "$*"; }
 
 usage() {
   cat <<'USAGE'


### PR DESCRIPTION
…eck SC2059

The datomic healthcheck used `nc -z localhost 4334` but netcat is not available in the openjdk:8u242-jre base image, causing the container to always report unhealthy. Replace with bash's built-in /dev/tcp which is guaranteed available. Also increase start_period to 30s and retries to 20 to give the JVM transactor more time on CI runners.

Fix shellcheck SC2059 warnings in docker-setup.sh and docker-user.sh by moving color variables out of printf format strings into %s arguments.

https://claude.ai/code/session_016YeAFxbw5tP5VPa95KGLWY

## Description:

**Related issue (if applicable):** fixes #<issue number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation if necessary
  - [ ] There is no commented out code in this PR.
  - [ ] My changes generate no new warnings (check the console)