### PR TITLE
Fix datomic healthcheck: use /proc/net/tcp instead of bash /dev/tcp

### DIFF
--- a/.github/workflows/docker-integration.yml
+++ b/.github/workflows/docker-integration.yml
@@ -43,53 +43,77 @@ jobs:
           fi
           echo "OK: Passwords match"
 
-      - name: Pull and start containers
+      - name: Start datomic (no deps)
         run: |
-          docker compose up -d
-          docker compose ps
+          docker compose pull
+          docker compose up -d --no-deps datomic
+          echo "Datomic container started, waiting for health..."
 
-      - name: Wait for healthy containers
+      - name: Wait for datomic healthy
         run: |
-          echo "Waiting for datomic healthcheck..."
-          for i in $(seq 1 60); do
-            STATUS=$(docker inspect --format='{{.State.Health.Status}}' "$(docker compose ps -q datomic)" 2>/dev/null || echo "waiting")
+          for i in $(seq 1 90); do
+            CID=$(docker compose ps -q datomic 2>/dev/null) || true
+            if [ -z "$CID" ]; then
+              echo "  [$i/90] datomic container not found yet"
+              sleep 2
+              continue
+            fi
+            RUNNING=$(docker inspect --format='{{.State.Running}}' "$CID" 2>/dev/null || echo "false")
+            STATUS=$(docker inspect --format='{{.State.Health.Status}}' "$CID" 2>/dev/null || echo "starting")
+            echo "  [$i/90] running=$RUNNING health=$STATUS"
             if [ "$STATUS" = "healthy" ]; then
               echo "Datomic is healthy (after ~$((i * 2))s)"
               break
             fi
-            if [ "$STATUS" = "unhealthy" ]; then
-              echo "FAIL: Datomic reported unhealthy"
+            if [ "$RUNNING" = "false" ]; then
+              echo "WARN: datomic container stopped — dumping logs"
               docker compose logs datomic
-              exit 1
+              echo "Container will restart (restart: always), continuing to wait..."
             fi
-            if [ "$i" -eq 60 ]; then
-              echo "FAIL: Datomic did not become healthy within 120s"
+            if [ "$i" -eq 90 ]; then
+              echo "FAIL: Datomic did not become healthy within 180s"
+              echo "=== container state ==="
+              docker inspect --format='{{json .State}}' "$CID" | python3 -m json.tool || true
+              echo "=== datomic logs ==="
               docker compose logs datomic
               exit 1
             fi
             sleep 2
           done
 
-          echo "Waiting for orcpub healthcheck..."
-          for i in $(seq 1 60); do
-            STATUS=$(docker inspect --format='{{.State.Health.Status}}' "$(docker compose ps -q orcpub)" 2>/dev/null || echo "waiting")
+      - name: Start orcpub and web
+        run: |
+          docker compose up -d
+          docker compose ps
+
+      - name: Wait for orcpub healthy
+        run: |
+          for i in $(seq 1 90); do
+            CID=$(docker compose ps -q orcpub 2>/dev/null) || true
+            if [ -z "$CID" ]; then
+              echo "  [$i/90] orcpub container not found yet"
+              sleep 2
+              continue
+            fi
+            STATUS=$(docker inspect --format='{{.State.Health.Status}}' "$CID" 2>/dev/null || echo "starting")
+            echo "  [$i/90] orcpub health=$STATUS"
             if [ "$STATUS" = "healthy" ]; then
               echo "orcpub is healthy (after ~$((i * 2))s)"
               break
             fi
             if [ "$STATUS" = "unhealthy" ]; then
               echo "FAIL: orcpub reported unhealthy"
+              echo "=== all logs ==="
               docker compose logs
               exit 1
             fi
-            if [ "$i" -eq 60 ]; then
-              echo "FAIL: orcpub did not become healthy within 120s"
+            if [ "$i" -eq 90 ]; then
+              echo "FAIL: orcpub did not become healthy within 180s"
               docker compose logs
               exit 1
             fi
             sleep 2
           done
-
           docker compose ps
 
       - name: Test — create user

--- a/docker-compose-build.yaml
+++ b/docker-compose-build.yaml
@@ -37,11 +37,11 @@ services:
       - ./data:/data
       - ./logs:/logs
     healthcheck:
-      test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/4334'"]
+      test: ["CMD-SHELL", "grep -q ':10EE ' /proc/net/tcp || grep -q ':10EE ' /proc/net/tcp6"]
       interval: 5s
       timeout: 3s
-      retries: 20
-      start_period: 30s
+      retries: 30
+      start_period: 40s
     restart: always
   web:
     image: nginx:alpine

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,11 +33,11 @@ services:
       - ./data:/data
       - ./logs:/logs
     healthcheck:
-      test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/4334'"]
+      test: ["CMD-SHELL", "grep -q ':10EE ' /proc/net/tcp || grep -q ':10EE ' /proc/net/tcp6"]
       interval: 5s
       timeout: 3s
-      retries: 20
-      start_period: 30s
+      retries: 30
+      start_period: 40s
     restart: always
   web:
     image: nginx:alpine


### PR DESCRIPTION
The previous healthcheck (bash -c 'echo > /dev/tcp/localhost/4334') fails on the openjdk:8u242-jre base image because CMD-SHELL runs via /bin/sh (dash) and /dev/tcp is a bash-only feature that may not be available in slim Debian images. Replace with grep on /proc/net/tcp which checks the kernel TCP listen table directly — requires only grep (always present) and works on any Linux container.

Port 4334 decimal = 10EE hex, so we grep for ':10EE ' in /proc/net/tcp with a fallback to /proc/net/tcp6 for IPv6 listeners.

Also restructure the CI workflow to start datomic independently first (docker compose up -d --no-deps datomic) so the depends_on chain doesn't block. This ensures we get container logs and health state on failure instead of an opaque "dependency failed to start" error.

https://claude.ai/code/session_01KkQBjzJHkceYz36K79jWri

## Description:

**Related issue (if applicable):** fixes #<issue number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation if necessary
  - [ ] There is no commented out code in this PR.
  - [ ] My changes generate no new warnings (check the console)